### PR TITLE
Disable high-volume ClickHouse diagnostic logs by default

### DIFF
--- a/docs-source/site/docs/setup/helm/install.md
+++ b/docs-source/site/docs/setup/helm/install.md
@@ -528,6 +528,22 @@ provider-neutral prerequisites, both Helm commands, restore validation,
 troubleshooting, and the optional single-command path when protected historical
 data is not required.
 
+#### ClickHouse Internal Diagnostic Retention
+
+OBaaS retains the high-volume ClickHouse `zookeeper_log` and
+`processors_profile_log` diagnostic tables for one day. These tables are useful
+for short-lived ClickHouse or ZooKeeper investigations, but longer retention can
+create substantial ClickHouse write, merge, and storage pressure under sustained
+telemetry load.
+
+The one-day retention is set in the OBaaS chart defaults. An operator can
+temporarily increase either retention period through
+`signoz.clickhouse.clickhouseOperator.zookeeperLog.ttl` or
+`signoz.clickhouse.clickhouseOperator.processorsProfileLog.ttl`; return it to
+one day after the investigation. Existing installations need a Helm upgrade to
+receive the new configuration. This configuration does not immediately delete
+diagnostic rows already stored in ClickHouse.
+
 #### SigNoz Cold Storage (`values-signoz-cold-storage.yaml`)
 
 Configures SigNoz ClickHouse cold storage so recent telemetry stays on the local persistent disk and older data is offloaded to S3-compatible object storage.

--- a/helm/infra-charts/obaas/values.yaml
+++ b/helm/infra-charts/obaas/values.yaml
@@ -903,6 +903,13 @@ signoz:
             chmod +x "$dst"
             echo "histogram-quantile installed successfully"
     clickhouseOperator:
+      # Keep high-volume ClickHouse diagnostic logs for one day. These logs are
+      # useful during short-lived investigations, but longer retention can put
+      # substantial write, merge, and storage pressure on ClickHouse.
+      zookeeperLog:
+        ttl: 1
+      processorsProfileLog:
+        ttl: 1
       image:
         registry: docker.io
         repository: altinity/clickhouse-operator


### PR DESCRIPTION
I reduced the OBaaS retention period for SigNoz’s high-volume ClickHouse diagnostic tables to one day as an immediate, maintainable mitigation against excessive ClickHouse write, merge, and storage pressure under sustained telemetry load. 

The bundled SigNoz chart currently exposes TTL settings but does not provide values to disable these diagnostics entirely, so we opened [SigNoz charts issue #905](https://github.com/SigNoz/charts/issues/905) requesting production-safe, opt-in defaults. Once that upstream change is released, OBaaS can disable these logs by default rather than relying on short retention.